### PR TITLE
Fix imprint phone placeholder and update job title to Principal Solution Architect

### DIFF
--- a/app/impressum/page.tsx
+++ b/app/impressum/page.tsx
@@ -46,7 +46,6 @@ export default function ImpressumPage() {
                 me@jomaendle.com
               </a>
             </p>
-            <p>Telefon: [optional]</p>
           </div>
         </section>
 

--- a/components/name-heading.tsx
+++ b/components/name-heading.tsx
@@ -6,7 +6,7 @@ import { useRef } from "react";
 
 export const NameHeading = ({
   showJobTitle,
-  jobTitle = "Principal Solution Architect",
+  jobTitle = "Principal Solution Architect – AI in SDLC",
 }: {
   showJobTitle?: boolean;
   jobTitle?: string;

--- a/components/name-heading.tsx
+++ b/components/name-heading.tsx
@@ -6,7 +6,7 @@ import { useRef } from "react";
 
 export const NameHeading = ({
   showJobTitle,
-  jobTitle = "Full-Stack Developer",
+  jobTitle = "Principal Solution Architect",
 }: {
   showJobTitle?: boolean;
   jobTitle?: string;

--- a/components/structured-data.tsx
+++ b/components/structured-data.tsx
@@ -72,7 +72,7 @@ export function PersonStructuredData() {
       "Jo Maendle",
       "Johannes Maendle",
     ],
-    jobTitle: "Full-Stack Developer",
+    jobTitle: "Principal Solution Architect",
     url: "https://jomaendle.com",
     sameAs: [
       "https://www.linkedin.com/in/johannes-maendle/",


### PR DESCRIPTION
- Remove leftover 'Telefon: [optional]' placeholder from the Impressum
  that was leaking into production
- Update the homepage job title from Full-Stack Developer to
  Principal Solution Architect
- Align the Person structured data jobTitle with the displayed title