### PR TITLE
Add the source copy for the AI impact audit page

### DIFF
--- a/app/ai-impact.md/route.ts
+++ b/app/ai-impact.md/route.ts
@@ -1,0 +1,14 @@
+import { renderAiImpactMarkdown } from "@/lib/ai-impact-markdown";
+
+export const dynamic = "force-static";
+
+const md = renderAiImpactMarkdown("en");
+
+export function GET() {
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/app/ai-impact/page.tsx
+++ b/app/ai-impact/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from "next";
+import { AiImpactContent } from "@/components/ai-impact/ai-impact-content";
+import { AiImpactStructuredData } from "@/components/structured-data";
+
+export const dynamic = "force-static";
+
+const title = "Measuring AI in engineering · 4-week audit";
+const description =
+  "Your team works with AI tools. In four weeks I measure what changed, from your own system and process data. No per-developer analysis.";
+
+const ogImage = `/api/og-image?title=${encodeURIComponent(
+  "Measuring AI in engineering",
+)}&description=${encodeURIComponent(
+  "A four-week audit. From your data, with no per-developer analysis.",
+)}`;
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    "measure AI impact engineering",
+    "AI coding assistant ROI",
+    "developer productivity audit",
+    "DORA metrics AI",
+    "engineering metrics without performance monitoring",
+    "works council AI measurement",
+    "GitHub Copilot impact measurement",
+    "fixed price engineering audit",
+  ],
+  alternates: {
+    canonical: "/ai-impact",
+    languages: {
+      de: "/ki-wirkung",
+      en: "/ai-impact",
+    },
+    types: {
+      "text/markdown": "/ai-impact.md",
+    },
+  },
+  openGraph: {
+    title: `${title} | Jo Mändle`,
+    description,
+    url: "https://www.jomaendle.com/ai-impact",
+    locale: "en_US",
+    type: "website",
+    images: [{ url: ogImage }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${title} | Jo Mändle`,
+    description,
+    images: [ogImage],
+  },
+};
+
+export default function AiImpactPage() {
+  return (
+    <>
+      <AiImpactStructuredData lang="en" />
+      <AiImpactContent lang="en" />
+    </>
+  );
+}

--- a/app/ki-wirkung.md/route.ts
+++ b/app/ki-wirkung.md/route.ts
@@ -1,0 +1,14 @@
+import { renderAiImpactMarkdown } from "@/lib/ai-impact-markdown";
+
+export const dynamic = "force-static";
+
+const md = renderAiImpactMarkdown("de");
+
+export function GET() {
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/app/ki-wirkung/page.tsx
+++ b/app/ki-wirkung/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+import { AiImpactContent } from "@/components/ai-impact/ai-impact-content";
+import { AiImpactStructuredData } from "@/components/structured-data";
+
+export const dynamic = "force-static";
+
+// The title carries the search term ("KI im Engineering messen") ahead of the
+// format, because the buyer searches for the problem and not for the word
+// "Audit". `| Jo Mändle` is appended by the template in app/layout.tsx.
+const title = "KI im Engineering messen · 4-Wochen-Audit";
+const description =
+  "Ihr Team arbeitet mit KI-Werkzeugen. Ich messe in vier Wochen aus Ihren eigenen System- und Prozessdaten, was sich verändert hat. Ohne personenbezogene Auswertung.";
+
+const ogImage = `/api/og-image?title=${encodeURIComponent(
+  "KI im Engineering messen",
+)}&description=${encodeURIComponent(
+  "4-Wochen-Audit. Aus Ihren Daten, ohne personenbezogene Auswertung.",
+)}`;
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    "KI Wirkung messen Engineering",
+    "AI Coding Assistant ROI",
+    "Developer Productivity Audit",
+    "DORA Metriken KI",
+    "KI Produktivität Entwicklung messen",
+    "Betriebsvereinbarung KI Entwicklung",
+    "Engineering Metriken ohne Leistungskontrolle",
+    "GitHub Copilot Nutzen belegen",
+    "Engineering Audit Festpreis",
+  ],
+  alternates: {
+    canonical: "/ki-wirkung",
+    languages: {
+      de: "/ki-wirkung",
+      en: "/ai-impact",
+    },
+    types: {
+      "text/markdown": "/ki-wirkung.md",
+    },
+  },
+  openGraph: {
+    title: `${title} | Jo Mändle`,
+    description,
+    url: "https://www.jomaendle.com/ki-wirkung",
+    locale: "de_DE",
+    type: "website",
+    images: [{ url: ogImage }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${title} | Jo Mändle`,
+    description,
+    images: [ogImage],
+  },
+};
+
+export default function KiWirkungPage() {
+  return (
+    <>
+      <AiImpactStructuredData lang="de" />
+      <AiImpactContent lang="de" />
+    </>
+  );
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -19,12 +19,14 @@
  */
 
 import { SITE } from "@/lib/config/site";
+import { AI_IMPACT_COPY } from "@/lib/state/ai-impact-copy";
 import { BUSINESS_COPY } from "@/lib/state/business-copy";
 import { CLIENT_PROJECTS } from "@/lib/state/business-projects";
 
 export const dynamic = "force-static";
 
 const t = BUSINESS_COPY.en;
+const aiImpact = AI_IMPACT_COPY.en;
 
 const services = t.services.items
   .map((item) => `- **${item.title}**: ${item.desc}`)
@@ -43,7 +45,7 @@ const content = `# ${SITE.name}
 
 > ${t.hero.lede} Freelance contract engineering with product teams and engineering leads.
 
-**${t.hero.availability}.** New engagements are not taken on before that date.
+**${t.hero.availability}.** Short, time-boxed mandates such as an audit or an architecture review can start at short notice. Ongoing work inside a team does not start before that quarter.
 
 Contact:
 - Email: ${SITE.contact.email}
@@ -56,6 +58,14 @@ Contact:
 - [Freelance Frontend & AI Engineering (DE)](https://www.jomaendle.com/business): German page describing services, stack, selected client work and how an engagement starts.
 - [Freelance Frontend & AI Engineering (EN)](https://www.jomaendle.com/business/en): English version of the same page.
 - [Markdown version (EN)](https://www.jomaendle.com/business/en.md): the full page as plain markdown.
+
+## Separate offer: AI impact audit
+
+A self-contained four-week mandate, priced and scoped on its own page. ${aiImpact.hero.lede} Measured at team and repository level, with no per-developer analysis.
+
+- [Measuring AI in engineering (EN)](https://www.jomaendle.com/ai-impact): scope, the four weeks, deliverables, price and FAQ.
+- [KI im Engineering messen (DE)](https://www.jomaendle.com/ki-wirkung): German version of the same page.
+- [Markdown version (EN)](https://www.jomaendle.com/ai-impact.md): the full page as plain markdown.
 
 ## Core services
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -78,6 +78,32 @@ export default function sitemap(): MetadataRoute.Sitemap {
         },
       },
     },
+    // The AI impact audit. A separate offer with its own buyer, so it carries
+    // the same priority as /business rather than sitting below it.
+    {
+      url: `${baseUrl}/ki-wirkung`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.9,
+      alternates: {
+        languages: {
+          de: `${baseUrl}/ki-wirkung`,
+          en: `${baseUrl}/ai-impact`,
+        },
+      },
+    },
+    {
+      url: `${baseUrl}/ai-impact`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+      alternates: {
+        languages: {
+          de: `${baseUrl}/ki-wirkung`,
+          en: `${baseUrl}/ai-impact`,
+        },
+      },
+    },
     {
       url: `${baseUrl}/about`,
       lastModified: now,

--- a/components/ai-impact/ai-impact-content.tsx
+++ b/components/ai-impact/ai-impact-content.tsx
@@ -1,0 +1,300 @@
+import { Link } from "next-view-transitions";
+import { H1, H2, H3 } from "@/components/ui/heading";
+import { Footer } from "@/components/ui/footer";
+import { PageTopBar } from "@/components/ui/page-top-bar";
+import { SITE } from "@/lib/config/site";
+import { AI_IMPACT_COPY, type Lang } from "@/lib/state/ai-impact-copy";
+
+/**
+ * AiImpactContent — the four-week AI impact audit, /ki-wirkung and /ai-impact.
+ *
+ * A server component with no client island at all: this page has no form, and
+ * the FAQ is native `details`/`summary`, so nothing here needs JavaScript.
+ *
+ * One call to action on the whole page, the booking link, repeated three times
+ * (hero, after the price, at the close). There is deliberately no inquiry form
+ * and no newsletter: the buyer here owns a budget line and is deciding whether
+ * to spend 20 minutes, not filling in six fields.
+ *
+ * Copy lives in `lib/state/ai-impact-copy.ts`, so this file is presentation
+ * only and the `.md` mirrors render from the same source.
+ */
+
+/** Shared link classes, so the three CTAs cannot drift apart. */
+const CTA_CLASS =
+  "inline-flex h-11 items-center justify-center rounded-[0.25rem] bg-foreground px-6 font-mono text-[0.75rem] uppercase tracking-[0.14em] text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
+function BookingCta({ label }: { label: string }) {
+  return (
+    <a
+      href={SITE.contact.booking}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={CTA_CLASS}
+    >
+      {label}
+      <span className="sr-only"> (opens in new window)</span>
+    </a>
+  );
+}
+
+export function AiImpactContent({ lang }: { lang: Lang }) {
+  const t = AI_IMPACT_COPY[lang];
+
+  return (
+    <div className="page-container">
+      <div
+        className="glass-container mx-auto flex max-w-3xl flex-col gap-16"
+        style={{ viewTransitionName: "main-content" }}
+        itemScope
+        itemType="https://schema.org/Service"
+      >
+        <PageTopBar
+          currentPath={t.path}
+          trailing={
+            <Link
+              href={t.switchHref}
+              hrefLang={lang === "de" ? "en" : "de"}
+              aria-label={t.switchLabel}
+              // -mx-2 keeps the optical position while the padding lifts the
+              // tap target to 44px tall, matching /business.
+              className="-mx-2 inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 font-mono text-sm tracking-[0.04em] text-muted-foreground transition-colors hover:text-brand"
+            >
+              {t.switchTo}
+            </Link>
+          }
+        />
+
+        <main
+          id="main-content"
+          tabIndex={-1}
+          lang={lang}
+          className="flex flex-col gap-16"
+        >
+          {/* Masthead. A `<header>` nested in `<main>` is not a banner
+              landmark, so this does not compete with the top bar. */}
+          <header className="flex flex-col gap-6">
+            <p className="mb-6 font-mono text-xs uppercase tracking-[0.16em] text-brand">
+              {t.hero.eyebrow}
+            </p>
+            <H1 className="max-w-[20ch]" itemProp="name">
+              {t.hero.heading}
+            </H1>
+            <p
+              className="max-w-[52ch] text-[1.05rem] leading-relaxed text-foreground/90"
+              itemProp="description"
+            >
+              {t.hero.lede}
+            </p>
+
+            {/* Capacity before the CTA rather than after it: two slots is the
+                first thing that disqualifies a reader, so it should not sit
+                below the fold. */}
+            <p className="font-mono text-[0.75rem] uppercase tracking-[0.14em] text-brand">
+              {t.hero.availability}
+            </p>
+
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-3 pt-1">
+              <BookingCta label={t.hero.cta} />
+              {/* Not a second CTA: an in-page jump for someone who wants to
+                  read the scope before booking anything. Text link, so it
+                  cannot read as a competing button. */}
+              <a
+                href="#audit"
+                className="inline-flex min-h-[44px] items-center rounded-[0.15rem] font-mono text-[0.75rem] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                {t.hero.jumpLabel}{" "}
+                <span aria-hidden="true" className="ml-1.5">
+                  ↓
+                </span>
+              </a>
+            </div>
+          </header>
+
+          {/* The problem, as hairline rows. Same construction as the services
+              list on /business: nothing here is clickable, so no `ledger-row`
+              and no horizontal bleed. */}
+          <section>
+            <H2>{t.problem.heading}</H2>
+            <div className="flex flex-col">
+              {t.problem.items.map((item) => (
+                <div key={item.title} className="border-b border-border py-4">
+                  <H3 interactive={false}>{item.title}</H3>
+                  <p className="mt-1 max-w-[62ch] text-muted-foreground">
+                    {item.desc}
+                  </p>
+                </div>
+              ))}
+            </div>
+            <p className="mt-6 max-w-[60ch] text-[1.05rem] leading-relaxed text-foreground/90">
+              {t.problem.closing}
+            </p>
+          </section>
+
+          {/* The audit itself. `scroll-mt-8` so the hero's jump link does not
+              park the heading under the top edge of the viewport. */}
+          <section id="audit" className="scroll-mt-8">
+            <H2>{t.audit.heading}</H2>
+            <p className="mb-8 max-w-[60ch] text-[1.05rem] leading-relaxed text-foreground/90">
+              {t.audit.lede}
+            </p>
+            <dl className="flex flex-col">
+              {t.audit.weeks.map((week) => (
+                <div
+                  key={week.label}
+                  className="flex flex-col gap-2 border-b border-border py-5 sm:flex-row sm:gap-6"
+                >
+                  <dt className="pt-1 font-mono text-[0.7rem] uppercase tracking-[0.14em] text-brand sm:w-24 sm:shrink-0">
+                    {week.label}
+                  </dt>
+                  <dd className="flex flex-col gap-1">
+                    <H3 interactive={false}>{week.title}</H3>
+                    <p className="max-w-[58ch] text-muted-foreground">
+                      {week.desc}
+                    </p>
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          {/* Deliverables */}
+          <section>
+            <H2>{t.outcome.heading}</H2>
+            <ul className="flex max-w-[60ch] flex-col gap-2 text-muted-foreground">
+              {t.outcome.items.map((item) => (
+                <li
+                  key={item}
+                  className="before:mr-2 before:text-brand before:content-['→']"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-6 max-w-[60ch] text-[1.05rem] leading-relaxed text-foreground/90">
+              {t.outcome.closing}
+            </p>
+          </section>
+
+          {/* The measurement argument. The most important section on the page,
+              so it is the only one with a filled surface: the same tinted panel
+              /business uses for its booking block, at a larger inset and with
+              the section heading pulled inside it. No new token, no new size. */}
+          <section className="rounded-[0.35rem] border border-brand/25 bg-brand/[0.05] p-6 sm:p-8">
+            <H2>{t.measurement.heading}</H2>
+            <div className="flex flex-col gap-8">
+              {t.measurement.blocks.map((block) => (
+                <div key={block.title} className="flex flex-col gap-3">
+                  <H3 interactive={false}>{block.title}</H3>
+                  {block.paragraphs.map((paragraph) => (
+                    <p
+                      key={paragraph}
+                      className="max-w-[60ch] leading-relaxed text-foreground/90"
+                    >
+                      {paragraph}
+                    </p>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Scope and price, then the second CTA. Someone who has just read
+              the number is at the point of deciding. */}
+          <section>
+            <H2>{t.scope.heading}</H2>
+            <p className="mb-8 font-mono text-[0.8rem] uppercase tracking-[0.12em] text-foreground">
+              {t.scope.priceLine}
+            </p>
+            <dl className="flex flex-col">
+              {t.scope.rows.map((row) => (
+                <div
+                  key={row.term}
+                  className="flex flex-col gap-2 border-b border-border py-4 sm:flex-row sm:gap-6"
+                >
+                  {/* w-40, not w-32: "Passt nicht, wenn" wrapped onto two
+                      lines at the narrower width and left the term column
+                      taller than the definition beside it. */}
+                  <dt className="font-mono text-[0.7rem] uppercase tracking-[0.14em] text-brand sm:w-40 sm:shrink-0">
+                    {row.term}
+                  </dt>
+                  <dd className="max-w-[58ch] text-muted-foreground">
+                    {row.desc}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+            <div className="mt-8">
+              <BookingCta label={t.hero.cta} />
+            </div>
+          </section>
+
+          {/* FAQ. Native disclosure widgets: keyboard and screen reader
+              behaviour comes from the browser, and the page ships no JS for it.
+              The default triangle is removed on both engines and replaced with
+              a `+` that rotates into a `×` when the row is open. */}
+          <section>
+            <H2>{t.faq.heading}</H2>
+            <div className="flex flex-col">
+              {t.faq.items.map((item) => (
+                <details
+                  key={item.question}
+                  className="group border-b border-border"
+                >
+                  <summary className="flex cursor-pointer list-none items-baseline justify-between gap-4 py-4 font-serif text-[1.2rem] leading-snug text-foreground transition-colors hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background [&::-webkit-details-marker]:hidden">
+                    {item.question}
+                    <span
+                      aria-hidden="true"
+                      className="shrink-0 font-mono text-sm text-brand transition-transform group-open:rotate-45"
+                    >
+                      +
+                    </span>
+                  </summary>
+                  <p className="max-w-[62ch] pb-5 text-muted-foreground">
+                    {item.answer}
+                  </p>
+                </details>
+              ))}
+            </div>
+          </section>
+
+          {/* Close. Third and last CTA. */}
+          <section>
+            <H2>{t.close.heading}</H2>
+            <p className="max-w-[52ch] font-serif text-[1.5rem] leading-snug text-foreground">
+              {t.close.lede}
+            </p>
+            <p className="mt-5 max-w-[60ch] text-[1.05rem] leading-relaxed text-foreground/90">
+              {t.close.body}
+            </p>
+
+            <div className="mt-8">
+              <BookingCta label={t.close.cta} />
+            </div>
+
+            <address className="mt-8 flex flex-col gap-2 text-sm not-italic text-muted-foreground">
+              <span>
+                {t.close.emailLabel}:{" "}
+                <a
+                  href={`mailto:${SITE.contact.email}`}
+                  className="text-foreground transition-colors hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  itemProp="email"
+                >
+                  {SITE.contact.email}
+                </a>
+              </span>
+              <a
+                href={t.markdownHref}
+                className="w-fit text-xs text-muted-foreground transition-colors hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                {t.markdownLabel}
+              </a>
+            </address>
+          </section>
+        </main>
+
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/components/ai-impact/ai-impact-content.tsx
+++ b/components/ai-impact/ai-impact-content.tsx
@@ -87,9 +87,9 @@ export function AiImpactContent({ lang }: { lang: Lang }) {
               {t.hero.lede}
             </p>
 
-            {/* Capacity before the CTA rather than after it: two slots is the
-                first thing that disqualifies a reader, so it should not sit
-                below the fold. */}
+            {/* The next free slot sits before the CTA rather than after it: a
+                date that does not work is the first thing that disqualifies a
+                reader, so it should not sit below the fold. */}
             <p className="font-mono text-[0.75rem] uppercase tracking-[0.14em] text-brand">
               {t.hero.availability}
             </p>

--- a/components/business/business-content.tsx
+++ b/components/business/business-content.tsx
@@ -149,6 +149,18 @@ export function BusinessContent({ lang }: { lang: Lang }) {
                 </div>
               ))}
             </div>
+            {/* One quiet pointer to the audit page, in the same muted style as
+                `stack.note` below. The two pages have different buyers, so this
+                stays a sentence rather than becoming a promoted block. */}
+            <p className="mt-5 max-w-[60ch] text-sm text-muted-foreground">
+              {t.services.note}{" "}
+              <Link
+                href={t.services.noteHref}
+                className="text-foreground underline decoration-border decoration-from-font underline-offset-[5px] transition-colors hover:text-brand hover:decoration-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                {t.services.noteLinkLabel}
+              </Link>
+            </p>
           </section>
 
           {/* Stack — breadth lives here so the hero can stay focused on the

--- a/components/structured-data.tsx
+++ b/components/structured-data.tsx
@@ -1,4 +1,6 @@
 import Script from "next/script";
+import { SITE } from "@/lib/config/site";
+import { AI_IMPACT_COPY, type Lang } from "@/lib/state/ai-impact-copy";
 
 interface PersonStructuredData {
   "@context": "https://schema.org";
@@ -268,6 +270,107 @@ export function BusinessStructuredData({ lang }: { lang: "de" | "en" }) {
   return <Script {...scriptProps} />;
 }
 
+/**
+ * `Service` + `FAQPage` JSON-LD for the AI impact audit route.
+ *
+ * Two graph nodes in one script. The `Service` describes the mandate and its
+ * provider; the `FAQPage` is generated from the same `AI_IMPACT_COPY.faq` the
+ * page renders, so the markup can never answer a question the page does not
+ * ask. Google retired FAQ rich results in 2026, but the type is still valid
+ * and is read by the AI crawlers `app/robots.ts` admits by name, which is the
+ * audience this page is written for.
+ *
+ * No `offers`: the published price is an entry point ("ab 10.000 €"), and a
+ * `PriceSpecification` would state it as the price of every engagement.
+ */
+export function AiImpactStructuredData({ lang }: { lang: Lang }) {
+  const isDe = lang === "de";
+  const t = AI_IMPACT_COPY[lang];
+  const url = `https://www.jomaendle.com${t.path}`;
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Service",
+        "@id": `${url}#service`,
+        name: isDe
+          ? "KI-Wirkung im Engineering messen · 4-Wochen-Audit"
+          : "Measuring AI impact in engineering · 4-week audit",
+        description: t.hero.lede,
+        url,
+        inLanguage: isDe ? "de-DE" : "en-US",
+        serviceType: isDe
+          ? "Audit der KI-Wirkung in der Softwareentwicklung"
+          : "Audit of AI impact on software delivery",
+        // Team- and repository-level only. Stating the category this way keeps
+        // the markup in step with the page's central claim: no per-developer
+        // analysis, which is what makes it survivable under § 87 BetrVG.
+        category: isDe
+          ? [
+              "Engineering-Kennzahlen",
+              "DORA-Metriken",
+              "KI-Einsatz in der Softwareentwicklung",
+              "Messung ohne personenbezogene Auswertung",
+            ]
+          : [
+              "Engineering metrics",
+              "DORA metrics",
+              "AI adoption in software delivery",
+              "Measurement without per-developer analysis",
+            ],
+        areaServed: [
+          { "@type": "Country", name: "Germany" },
+          { "@type": "Country", name: "Austria" },
+          { "@type": "Country", name: "Switzerland" },
+          { "@type": "Place", name: "Remote / EU" },
+        ],
+        audience: {
+          "@type": "BusinessAudience",
+          audienceType: isDe
+            ? "VP Engineering, CTO, Budgetverantwortliche"
+            : "VP Engineering, CTO, budget owners",
+        },
+        provider: {
+          "@type": "Person",
+          "@id": "https://www.jomaendle.com#person",
+          name: "Johannes Mändle",
+          alternateName: ["Jo Mändle", "Jo Maendle", "Johannes Maendle"],
+          jobTitle: "Principal Solution Architect",
+          url: "https://www.jomaendle.com",
+          email: `mailto:${SITE.contact.email}`,
+          sameAs: [
+            "https://www.linkedin.com/in/johannes-maendle/",
+            "https://github.com/jomaendle",
+          ],
+        },
+        potentialAction: {
+          "@type": "ReserveAction",
+          name: t.hero.cta,
+          target: SITE.contact.booking,
+        },
+      },
+      {
+        "@type": "FAQPage",
+        "@id": `${url}#faq`,
+        inLanguage: isDe ? "de-DE" : "en-US",
+        mainEntity: t.faq.items.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: { "@type": "Answer", text: item.answer },
+        })),
+      },
+    ],
+  };
+
+  const scriptProps = {
+    id: `ai-impact-structured-data-${lang}`,
+    type: "application/ld+json",
+    dangerouslySetInnerHTML: { __html: JSON.stringify(structuredData) },
+  };
+  return <Script {...scriptProps} />;
+}
+
 export function WebsiteStructuredData() {
   const structuredData: WebsiteStructuredData = {
     "@context": "https://schema.org",
@@ -285,7 +388,8 @@ export function WebsiteStructuredData() {
       "@type": "SearchAction",
       target: {
         "@type": "EntryPoint",
-        urlTemplate: "https://www.jomaendle.com/blog?search={search_term_string}",
+        urlTemplate:
+          "https://www.jomaendle.com/blog?search={search_term_string}",
       },
       "query-input": "required name=search_term_string",
     },

--- a/docs/ki-wirkung-copy.md
+++ b/docs/ki-wirkung-copy.md
@@ -1,0 +1,133 @@
+# Landing Page: AI-Engineering-Audit
+
+**Route:** `/ki-wirkung` (DE) · `/ai-impact` (EN)
+**Ein Angebot, ein CTA. Keine Leistungsübersicht.**
+
+---
+
+## 1. Above the fold
+
+**Eyebrow:** Audit · 4 Wochen · Festpreis
+
+**H1:**
+# Ihr Team arbeitet mit KI. Können Sie belegen, was es bringt?
+
+**Subline:**
+Lizenzen sind gekauft, die Nutzung ist unklar, und in der nächsten Budgetrunde fragt jemand nach Zahlen. Ich messe in vier Wochen, was sich tatsächlich verändert hat — und was nicht.
+
+**Primär-CTA:** Erstgespräch buchen (20 Min)
+**Sekundär:** Was im Audit passiert ↓
+
+**Verfügbarkeitszeile:** Nächster Audit-Slot: [MONAT]. Zwei parallel, mehr nicht.
+
+---
+
+## 2. Das Problem (H2: Woran Sie das erkennen)
+
+Drei Sätze, jeweils als Karte oder Liste. Keine Icons nötig.
+
+- **Die Lizenzkosten stehen im Budget, der Nutzen nicht.** Sie zahlen pro Entwickler:in und Monat. Was zurückkommt, steht in keiner Zeile.
+- **Die Erfahrungsberichte widersprechen sich.** Zwei Teams sind begeistert, drei nutzen es nach der Einführungswoche nicht mehr. Niemand weiß, warum.
+- **Vorhandene Zahlen tragen nicht.** Akzeptierte Vorschläge und Nutzungsquoten sagen nichts über Durchlaufzeit, Reviewaufwand oder Fehlerrate im Betrieb.
+
+**Abschlusssatz:**
+Das ist kein Toolproblem. Es ist ein Messproblem — und es lässt sich lösen, ohne einzelne Entwickler:innen zu bewerten.
+
+---
+
+## 3. Das Angebot (H2: Das Audit)
+
+**Untertitel:** Vier Wochen, zwei Termine pro Woche, ein Ergebnisdokument.
+
+**Woche 1 — Baseline**
+Auswertung von Git, CI und Ticketsystem der letzten zwölf Monate. Durchlaufzeit von Commit bis Produktion, Reviewdauer, Änderungsrate nach Merge, Rollbacks. Der Stand vor der KI-Einführung, aus vorhandenen Daten.
+
+**Woche 2 — Ist-Aufnahme**
+Wo Agenten heute wirklich eingesetzt werden. Sechs bis acht Gespräche à 30 Minuten, quer durch Teams und Senioritäten. Nicht anonymisierte Umfrage — Gespräch.
+
+**Woche 3 — Wirkungsanalyse**
+Dieselben Kennzahlen nach der Einführung, gegen die Baseline gestellt. Getrennt nach Team, Codebase-Alter und Aufgabentyp. Hier zeigt sich in der Regel, dass der Effekt nicht gleichmäßig verteilt ist.
+
+**Woche 4 — Empfehlung**
+Wo ausgebaut wird, wo gestoppt, was die Blockade ist. Mit Aufwand und erwartetem Effekt pro Maßnahme.
+
+---
+
+## 4. Was Sie danach in der Hand haben (H2)
+
+- Ein Kennzahlen-Set, das Ihr Team ohne mich fortschreiben kann — Definitionen, Abfragen, Skripte
+- Baseline und Ist-Wert, belegt aus Systemdaten statt aus Selbstauskunft
+- Eine Seite für die Geschäftsführung, die eine Budgetentscheidung trägt
+- Drei bis fünf priorisierte Maßnahmen mit Aufwandsschätzung
+- Alle Rohdaten und Auswertungsskripte, in Ihrem Repository
+
+Kein Foliensatz, den nach vier Wochen niemand mehr öffnet.
+
+---
+
+## 5. Der Punkt, an dem andere Anbieter scheitern (H2)
+
+**H3: Messung ohne Leistungskontrolle**
+
+Werkzeuge aus den USA messen pro Entwickler:in. In Deutschland ist das mitbestimmungspflichtig und in vielen Häusern der Grund, warum die Einführung im Betriebsrat hängen bleibt.
+
+Ich messe auf Team- und Repository-Ebene. Keine personenbezogene Auswertung, keine Rangliste, kein individuelles Profil. Das Kennzahlen-Set ist so aufgebaut, dass es einer Betriebsvereinbarung standhält — ich liefere die Beschreibung mit, die Sie dafür brauchen.
+
+**H3: Ich habe das selbst eingeführt, nicht nur bewertet**
+
+Als Principal Solution Architect in einem Konzern mit mehreren hundert Entwickler:innen, unter denselben Zwängen, die Sie kennen: Betriebsrat, Beschaffung, gewachsene Codebases, Teams mit Fristen.
+
+---
+
+## 6. Rahmen (H2: Umfang und Preis)
+
+**[X].000 € Festpreis · 4 Wochen · remote, ein Tag vor Ort optional**
+
+Enthalten: Datenauswertung, sechs bis acht Interviews, Ergebnisdokument, Abschlusspräsentation, Übergabe der Skripte.
+
+Nicht enthalten: Umsetzung der Maßnahmen. Das ist ein eigenes Mandat und Sie entscheiden danach, ob mit mir oder ohne.
+
+**Passt, wenn:** 50 bis 800 Entwickler:innen, KI-Werkzeuge seit mindestens drei Monaten im Einsatz, Git und CI mit auswertbarer Historie.
+
+**Passt nicht, wenn:** Sie noch vor der Einführung stehen. Dann fehlt die Baseline und das Audit misst nichts. Melden Sie sich in einem Quartal.
+
+---
+
+## 7. Häufige Fragen (H2)
+
+**Was, wenn das Ergebnis negativ ausfällt?**
+Dann steht das im Dokument. Ein Audit, dessen Ergebnis vorher feststeht, ist keins wert. In dem Fall haben Sie eine belastbare Grundlage, Lizenzen zu reduzieren — das rechnet sich schneller als jede Optimierung.
+
+**Bekommen Sie Zugriff auf unseren Code?**
+Nein. Ich brauche Metadaten: Commit-Zeitstempel, Pull-Request-Historie, CI-Läufe, Tickets. Kein Quellcode verlässt Ihr Haus, das steht im Vertrag.
+
+**Wie viel Zeit kostet uns das?**
+Sechs bis acht Interviews à 30 Minuten, ein technischer Zugang in Woche 1, ein Abschlusstermin. Zusammen unter zehn Stunden auf Ihrer Seite.
+
+**Warum nicht eines der fertigen Werkzeuge?**
+Können Sie — nach dem Audit wissen Sie, welche Kennzahlen bei Ihnen aussagekräftig sind. Vorher kaufen Sie ein Dashboard und lernen erst danach, was Sie eigentlich hätten messen wollen.
+
+---
+
+## 8. Abschluss (H2)
+
+**20 Minuten. Ich stelle Fragen, Sie entscheiden danach.**
+
+Im Gespräch klären wir, ob Ihre Datenlage ein Audit überhaupt trägt. Wenn nicht, sage ich das im Gespräch und nicht nach der Beauftragung.
+
+**CTA:** Termin wählen → [Kalender-Link]
+**Alternativ:** [E-Mail]
+
+---
+
+## Umsetzungshinweise
+
+**Was von der bestehenden Seite übernommen wird:** Layout, Typografie, Footer, Datenschutz. Keine neue Gestaltung.
+
+**Was auf dieser Seite nicht auftaucht:** Tech-Stack-Liste, Framework-Logos, Referenzprojekte aus dem Frontend-Bereich, das Wort „Freelancer", Formular mit sechs Feldern. Käufer:in ist hier VP Engineering oder CTO — die Frage ist Budgetverantwortung, nicht Entwicklerkapazität.
+
+**Ein einziger CTA über die gesamte Seite.** Kalenderlink, dreimal wiederholt. Kein Kontaktformular parallel.
+
+**Verlinkung von `/business`:** ein Satz unter den Leistungen, nicht prominent. Die beiden Seiten haben verschiedene Käufer:innen und dürfen sich nicht gegenseitig verwässern.
+
+**Vor dem Livegang zu füllen:** Preis, nächster verfügbarer Monat, Kalenderlink.

--- a/lib/ai-impact-markdown.ts
+++ b/lib/ai-impact-markdown.ts
@@ -1,0 +1,85 @@
+/**
+ * Agent-readable markdown mirror of the AI impact audit page.
+ *
+ * Both `/ki-wirkung.md` and `/ai-impact.md` render through this function, so
+ * the mirror is derived from the same `AI_IMPACT_COPY` the page renders from.
+ * The `/business.md` mirrors work the same way, for the same reason: a
+ * hand-maintained template literal drifts the first time the copy moves.
+ */
+
+import { SITE } from "@/lib/config/site";
+import { AI_IMPACT_COPY, type Lang } from "@/lib/state/ai-impact-copy";
+
+const BASE_URL = "https://www.jomaendle.com";
+
+export function renderAiImpactMarkdown(lang: Lang): string {
+  const t = AI_IMPACT_COPY[lang];
+  const isDe = lang === "de";
+
+  const weeks = t.audit.weeks
+    .map((week) => `### ${week.label} · ${week.title}\n\n${week.desc}`)
+    .join("\n\n");
+
+  const faq = t.faq.items
+    .map((item) => `### ${item.question}\n\n${item.answer}`)
+    .join("\n\n");
+
+  const measurement = t.measurement.blocks
+    .map((block) => `### ${block.title}\n\n${block.paragraphs.join("\n\n")}`)
+    .join("\n\n");
+
+  return `# ${t.hero.heading}
+
+${t.hero.eyebrow}
+
+${t.hero.lede}
+
+**${t.hero.availability}**
+
+- ${t.hero.cta}: ${SITE.contact.booking}
+- ${isDe ? "E-Mail" : "Email"}: ${SITE.contact.email}
+
+## ${t.problem.heading}
+
+${t.problem.items.map((item) => `- **${item.title}** ${item.desc}`).join("\n")}
+
+${t.problem.closing}
+
+## ${t.audit.heading}
+
+${t.audit.lede}
+
+${weeks}
+
+## ${t.outcome.heading}
+
+${t.outcome.items.map((item) => `- ${item}`).join("\n")}
+
+${t.outcome.closing}
+
+## ${t.measurement.heading}
+
+${measurement}
+
+## ${t.scope.heading}
+
+**${t.scope.priceLine}**
+
+${t.scope.rows.map((row) => `- **${row.term}**: ${row.desc}`).join("\n")}
+
+## ${t.faq.heading}
+
+${faq}
+
+## ${t.close.heading}
+
+${t.close.lede}
+
+${t.close.body}
+
+- ${t.close.cta}: ${SITE.contact.booking}
+- ${isDe ? "E-Mail" : "Email"}: ${SITE.contact.email}
+- HTML version: ${BASE_URL}${t.path}
+- ${isDe ? "English version" : "German version"}: ${BASE_URL}${t.switchHref}
+`;
+}

--- a/lib/business-markdown.ts
+++ b/lib/business-markdown.ts
@@ -18,7 +18,11 @@ export function renderBusinessMarkdown(lang: Lang): string {
   const projects = CLIENT_PROJECTS.map((project) =>
     [
       `### ${project.title} · ${project.href}`,
-      `**${[project.period[lang], project.role[lang], project.stack?.join(" · ")]
+      `**${[
+        project.period[lang],
+        project.role[lang],
+        project.stack?.join(" · "),
+      ]
         .filter(Boolean)
         .join(" · ")}**`,
       "",
@@ -51,6 +55,8 @@ ${t.pitch.paragraphs.join("\n\n")}
 ## ${t.services.heading}
 
 ${t.services.items.map((item) => `- **${item.title}**: ${item.desc}`).join("\n")}
+
+${t.services.note} [${t.services.noteLinkLabel}](https://www.jomaendle.com${t.services.noteHref})
 
 ## ${t.stack.heading}
 

--- a/lib/state/ai-impact-copy.ts
+++ b/lib/state/ai-impact-copy.ts
@@ -1,0 +1,391 @@
+/**
+ * Bilingual copy for the AI-impact audit route (/ki-wirkung, /ai-impact).
+ *
+ * Same shape as `lib/state/business-copy.ts`: copy is data, the page component
+ * is presentation only, and `lib/ai-impact-markdown.ts` renders the `.md`
+ * mirrors from this file rather than from a hand-maintained template.
+ *
+ * Positioning: one self-contained offer, sold to whoever owns the budget line.
+ * /business sells developer capacity to engineering leads; this page sells a
+ * four-week measurement mandate to a VP Engineering or CTO. The two pages
+ * deliberately share no sections and link to each other exactly once.
+ *
+ * Source text: `docs/ki-wirkung-copy.md`. Taken over as written, with one
+ * systematic exception: the source uses em dashes, which the site's writing
+ * voice bans outright. Each one is resolved into two sentences or a colon, the
+ * fix that rule asks for. No sentence was added, cut or re-pitched.
+ */
+
+export type Lang = "de" | "en";
+
+/**
+ * The two values that go stale.
+ *
+ * Both appear in more than one place once the markdown mirrors are counted, so
+ * they are interpolated rather than typed out. Change them here and the page,
+ * both mirrors and the JSON-LD follow.
+ *
+ * `PRICE_FROM` is an entry price, not the fixed price for every engagement:
+ * scope moves with headcount and with how much of the Git and CI history is
+ * actually queryable.
+ */
+const PRICE_FROM = {
+  de: "Festpreis ab 10.000 €",
+  en: "Fixed price from €10,000",
+};
+const NEXT_SLOT = { de: "September 2026", en: "September 2026" };
+
+interface LabelledItem {
+  title: string;
+  desc: string;
+}
+
+/** One week of the audit: mono week label, serif title, body. */
+interface AuditWeek {
+  label: string;
+  title: string;
+  desc: string;
+}
+
+/** One row of the scope table: mono term, body definition. */
+interface ScopeRow {
+  term: string;
+  desc: string;
+}
+
+interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+export interface AiImpactCopy {
+  /** Label on the language switch (the language it switches *to*). */
+  switchTo: string;
+  switchHref: string;
+  switchLabel: string;
+  /** Route of the page itself, for the top bar's self-link suppression. */
+  path: string;
+  markdownHref: string;
+  markdownLabel: string;
+  hero: {
+    eyebrow: string;
+    heading: string;
+    lede: string;
+    /** Next free audit slot, interpolated from `NEXT_SLOT`. */
+    availability: string;
+    cta: string;
+    /** In-page jump to the audit section. Navigation, not a second CTA. */
+    jumpLabel: string;
+  };
+  problem: { heading: string; items: LabelledItem[]; closing: string };
+  audit: { heading: string; lede: string; weeks: AuditWeek[] };
+  outcome: { heading: string; items: string[]; closing: string };
+  /**
+   * The measurement section. This is the page's argument, so it renders inside
+   * the brand-tinted panel and carries two h3s instead of a flat body.
+   */
+  measurement: {
+    heading: string;
+    blocks: { title: string; paragraphs: string[] }[];
+  };
+  scope: { heading: string; priceLine: string; rows: ScopeRow[] };
+  faq: { heading: string; items: FaqItem[] };
+  close: {
+    heading: string;
+    lede: string;
+    body: string;
+    cta: string;
+    emailLabel: string;
+  };
+}
+
+export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
+  de: {
+    switchTo: "EN",
+    switchHref: "/ai-impact",
+    switchLabel: "Switch to English",
+    path: "/ki-wirkung",
+    markdownHref: "/ki-wirkung.md",
+    markdownLabel: "Diese Seite als Markdown ansehen",
+    hero: {
+      eyebrow: "Audit · 4 Wochen · Festpreis",
+      heading: "Ihr Team arbeitet mit KI. Können Sie belegen, was es bringt?",
+      lede: "Lizenzen sind gekauft, die Nutzung ist unklar, und in der nächsten Budgetrunde fragt jemand nach Zahlen. Ich messe in vier Wochen, was sich tatsächlich verändert hat. Und was nicht.",
+      availability: `Nächster Audit-Slot: ${NEXT_SLOT.de}. Zwei parallel, mehr nicht.`,
+      cta: "Erstgespräch buchen (20 Min)",
+      jumpLabel: "Was im Audit passiert",
+    },
+    problem: {
+      heading: "Woran Sie das erkennen",
+      items: [
+        {
+          title: "Die Lizenzkosten stehen im Budget, der Nutzen nicht.",
+          desc: "Sie zahlen pro Entwickler:in und Monat. Was zurückkommt, steht in keiner Zeile.",
+        },
+        {
+          title: "Die Erfahrungsberichte widersprechen sich.",
+          desc: "Zwei Teams sind begeistert, drei nutzen es nach der Einführungswoche nicht mehr. Niemand weiß, warum.",
+        },
+        {
+          title: "Vorhandene Zahlen tragen nicht.",
+          desc: "Akzeptierte Vorschläge und Nutzungsquoten sagen nichts über Durchlaufzeit, Reviewaufwand oder Fehlerrate im Betrieb.",
+        },
+      ],
+      closing:
+        "Das ist kein Toolproblem. Es ist ein Messproblem, und es lässt sich lösen, ohne einzelne Entwickler:innen zu bewerten.",
+    },
+    audit: {
+      heading: "Das Audit",
+      lede: "Vier Wochen, zwei Termine pro Woche, ein Ergebnisdokument.",
+      weeks: [
+        {
+          label: "Woche 1",
+          title: "Baseline",
+          desc: "Auswertung von Git, CI und Ticketsystem der letzten zwölf Monate. Durchlaufzeit von Commit bis Produktion, Reviewdauer, Änderungsrate nach Merge, Rollbacks. Der Stand vor der KI-Einführung, aus vorhandenen Daten.",
+        },
+        {
+          label: "Woche 2",
+          title: "Ist-Aufnahme",
+          desc: "Wo Agenten heute wirklich eingesetzt werden. Sechs bis acht Gespräche à 30 Minuten, quer durch Teams und Senioritäten. Gespräche, keine anonymisierte Umfrage.",
+        },
+        {
+          label: "Woche 3",
+          title: "Wirkungsanalyse",
+          desc: "Dieselben Kennzahlen nach der Einführung, gegen die Baseline gestellt. Getrennt nach Team, Codebase-Alter und Aufgabentyp. Hier zeigt sich in der Regel, dass der Effekt nicht gleichmäßig verteilt ist.",
+        },
+        {
+          label: "Woche 4",
+          title: "Empfehlung",
+          desc: "Wo ausgebaut wird, wo gestoppt, was die Blockade ist. Mit Aufwand und erwartetem Effekt pro Maßnahme.",
+        },
+      ],
+    },
+    outcome: {
+      heading: "Was Sie danach in der Hand haben",
+      items: [
+        "Ein Kennzahlen-Set, das Ihr Team ohne mich fortschreiben kann: Definitionen, Abfragen, Skripte",
+        "Baseline und Ist-Wert, belegt aus Systemdaten statt aus Selbstauskunft",
+        "Eine Seite für die Geschäftsführung, die eine Budgetentscheidung trägt",
+        "Drei bis fünf priorisierte Maßnahmen mit Aufwandsschätzung",
+        "Alle Rohdaten und Auswertungsskripte, in Ihrem Repository",
+      ],
+      closing: "Kein Foliensatz, den nach vier Wochen niemand mehr öffnet.",
+    },
+    measurement: {
+      heading: "Der Punkt, an dem andere Anbieter scheitern",
+      blocks: [
+        {
+          title: "Messung ohne Leistungskontrolle",
+          paragraphs: [
+            "Werkzeuge aus den USA messen pro Entwickler:in. In Deutschland ist das mitbestimmungspflichtig und in vielen Häusern der Grund, warum die Einführung im Betriebsrat hängen bleibt.",
+            "Ich messe auf Team- und Repository-Ebene. Keine personenbezogene Auswertung, keine Rangliste, kein individuelles Profil. Das Kennzahlen-Set ist so aufgebaut, dass es einer Betriebsvereinbarung standhält. Die Beschreibung, die Sie dafür brauchen, liefere ich mit.",
+          ],
+        },
+        {
+          title: "Ich habe das selbst eingeführt, nicht nur bewertet",
+          paragraphs: [
+            "Als Principal Solution Architect in einem Konzern mit mehreren hundert Entwickler:innen, unter denselben Zwängen, die Sie kennen: Betriebsrat, Beschaffung, gewachsene Codebases, Teams mit Fristen.",
+          ],
+        },
+      ],
+    },
+    scope: {
+      heading: "Umfang und Preis",
+      priceLine: `${PRICE_FROM.de} · 4 Wochen · remote, ein Tag vor Ort optional`,
+      rows: [
+        {
+          term: "Enthalten",
+          desc: "Datenauswertung, sechs bis acht Interviews, Ergebnisdokument, Abschlusspräsentation, Übergabe der Skripte.",
+        },
+        {
+          term: "Nicht enthalten",
+          desc: "Umsetzung der Maßnahmen. Das ist ein eigenes Mandat und Sie entscheiden danach, ob mit mir oder ohne.",
+        },
+        {
+          term: "Passt, wenn",
+          desc: "50 bis 800 Entwickler:innen, KI-Werkzeuge seit mindestens drei Monaten im Einsatz, Git und CI mit auswertbarer Historie.",
+        },
+        {
+          term: "Passt nicht, wenn",
+          desc: "Sie noch vor der Einführung stehen. Dann fehlt die Baseline und das Audit misst nichts. Melden Sie sich in einem Quartal.",
+        },
+      ],
+    },
+    faq: {
+      heading: "Häufige Fragen",
+      items: [
+        {
+          question: "Was, wenn das Ergebnis negativ ausfällt?",
+          answer:
+            "Dann steht das im Dokument. Ein Audit, dessen Ergebnis vorher feststeht, ist keins wert. In dem Fall haben Sie eine belastbare Grundlage, Lizenzen zu reduzieren. Das rechnet sich schneller als jede Optimierung.",
+        },
+        {
+          question: "Bekommen Sie Zugriff auf unseren Code?",
+          answer:
+            "Nein. Ich brauche Metadaten: Commit-Zeitstempel, Pull-Request-Historie, CI-Läufe, Tickets. Kein Quellcode verlässt Ihr Haus, das steht im Vertrag.",
+        },
+        {
+          question: "Wie viel Zeit kostet uns das?",
+          answer:
+            "Sechs bis acht Interviews à 30 Minuten, ein technischer Zugang in Woche 1, ein Abschlusstermin. Zusammen unter zehn Stunden auf Ihrer Seite.",
+        },
+        {
+          question: "Warum nicht eines der fertigen Werkzeuge?",
+          answer:
+            "Können Sie. Nach dem Audit wissen Sie, welche Kennzahlen bei Ihnen aussagekräftig sind. Vorher kaufen Sie ein Dashboard und lernen erst danach, was Sie eigentlich hätten messen wollen.",
+        },
+      ],
+    },
+    close: {
+      heading: "Abschluss",
+      lede: "20 Minuten. Ich stelle Fragen, Sie entscheiden danach.",
+      body: "Im Gespräch klären wir, ob Ihre Datenlage ein Audit überhaupt trägt. Wenn nicht, sage ich das im Gespräch und nicht nach der Beauftragung.",
+      cta: "Termin wählen",
+      emailLabel: "Alternativ per E-Mail",
+    },
+  },
+  en: {
+    switchTo: "DE",
+    switchHref: "/ki-wirkung",
+    switchLabel: "Zu Deutsch wechseln",
+    path: "/ai-impact",
+    markdownHref: "/ai-impact.md",
+    markdownLabel: "View this page as Markdown",
+    hero: {
+      eyebrow: "Audit · 4 weeks · fixed price",
+      heading: "Your team works with AI. Can you show what it returns?",
+      lede: "The licences are paid for, the usage is unclear, and in the next budget round someone will ask for numbers. In four weeks I measure what actually changed. And what didn't.",
+      availability: `Next audit slot: ${NEXT_SLOT.en}. Two at a time, no more.`,
+      cta: "Book an intro call (20 min)",
+      jumpLabel: "What happens in the audit",
+    },
+    problem: {
+      heading: "How you know this is you",
+      items: [
+        {
+          title: "The licence cost is in the budget. The return is not.",
+          desc: "You pay per developer per month. Nothing on the other side of that line is written down.",
+        },
+        {
+          title: "The reports from your teams contradict each other.",
+          desc: "Two teams are delighted, three stopped using it after the rollout week. Nobody knows why.",
+        },
+        {
+          title: "The numbers you already have don't carry the decision.",
+          desc: "Acceptance rates and usage quotas say nothing about lead time, review effort or failure rate in production.",
+        },
+      ],
+      closing:
+        "This is not a tooling problem. It is a measurement problem, and it can be solved without rating individual developers.",
+    },
+    audit: {
+      heading: "The audit",
+      lede: "Four weeks, two sessions a week, one written result.",
+      weeks: [
+        {
+          label: "Week 1",
+          title: "Baseline",
+          desc: "Analysis of Git, CI and the ticket system over the last twelve months. Lead time from commit to production, review duration, change rate after merge, rollbacks. The state before AI arrived, from data you already hold.",
+        },
+        {
+          label: "Week 2",
+          title: "Current practice",
+          desc: "Where agents are genuinely used today. Six to eight conversations of 30 minutes, across teams and seniority levels. Conversations, not an anonymous survey.",
+        },
+        {
+          label: "Week 3",
+          title: "Impact analysis",
+          desc: "The same metrics after the rollout, set against the baseline. Split by team, codebase age and type of work. This is usually where it becomes clear that the effect is not evenly distributed.",
+        },
+        {
+          label: "Week 4",
+          title: "Recommendation",
+          desc: "Where to expand, where to stop, what the blocker is. With effort and expected effect for each measure.",
+        },
+      ],
+    },
+    outcome: {
+      heading: "What you hold afterwards",
+      items: [
+        "A metric set your team can keep running without me: definitions, queries, scripts",
+        "Baseline and current value, evidenced from system data rather than self-reporting",
+        "One page for the executive board that can carry a budget decision",
+        "Three to five prioritised measures with an effort estimate",
+        "All raw data and analysis scripts, in your repository",
+      ],
+      closing: "No slide deck that nobody opens again after four weeks.",
+    },
+    measurement: {
+      heading: "Where other providers fail",
+      blocks: [
+        {
+          title: "Measurement without performance monitoring",
+          paragraphs: [
+            "Tools built in the US measure per developer. In Germany that triggers works council codetermination, and in many companies it is the reason a rollout stalls there.",
+            "I measure at team and repository level. No personal analysis, no ranking, no individual profile. The metric set is built to hold up in a works agreement. I supply the description you need for it.",
+          ],
+        },
+        {
+          title: "I have introduced this myself, not only assessed it",
+          paragraphs: [
+            "As a Principal Solution Architect in a corporate group with several hundred developers, under the same constraints you know: works council, procurement, mature codebases, teams with deadlines.",
+          ],
+        },
+      ],
+    },
+    scope: {
+      heading: "Scope and price",
+      priceLine: `${PRICE_FROM.en} · 4 weeks · remote, one day on site optional`,
+      rows: [
+        {
+          term: "Included",
+          desc: "Data analysis, six to eight interviews, written result, closing presentation, handover of the scripts.",
+        },
+        {
+          term: "Not included",
+          desc: "Implementing the measures. That is a separate mandate and you decide afterwards whether it runs with me or without.",
+        },
+        {
+          term: "Fits if",
+          desc: "50 to 800 developers, AI tools in use for at least three months, Git and CI with a history that can be queried.",
+        },
+        {
+          term: "Does not fit if",
+          desc: "You are still before the rollout. Then the baseline is missing and the audit measures nothing. Get in touch in a quarter.",
+        },
+      ],
+    },
+    faq: {
+      heading: "Common questions",
+      items: [
+        {
+          question: "What if the result comes out negative?",
+          answer:
+            "Then that is what the document says. An audit whose result is settled in advance is worth nothing. In that case you have solid grounds to reduce licences. That pays off faster than any optimisation.",
+        },
+        {
+          question: "Do you get access to our code?",
+          answer:
+            "No. I need metadata: commit timestamps, pull request history, CI runs, tickets. No source code leaves your company, and that is in the contract.",
+        },
+        {
+          question: "How much of our time does this cost?",
+          answer:
+            "Six to eight interviews of 30 minutes, one technical access in week 1, one closing session. Under ten hours on your side in total.",
+        },
+        {
+          question: "Why not one of the off-the-shelf tools?",
+          answer:
+            "You can. After the audit you know which metrics are meaningful in your company. Before it, you buy a dashboard and only then learn what you should have been measuring.",
+        },
+      ],
+    },
+    close: {
+      heading: "Closing",
+      lede: "20 minutes. I ask the questions, you decide afterwards.",
+      body: "In the call we work out whether your data even carries an audit. If it doesn't, I say so in the call and not after you have signed.",
+      cta: "Pick a time",
+      emailLabel: "Or by email",
+    },
+  },
+};

--- a/lib/state/ai-impact-copy.ts
+++ b/lib/state/ai-impact-copy.ts
@@ -10,10 +10,19 @@
  * four-week measurement mandate to a VP Engineering or CTO. The two pages
  * deliberately share no sections and link to each other exactly once.
  *
- * Source text: `docs/ki-wirkung-copy.md`. Taken over as written, with one
- * systematic exception: the source uses em dashes, which the site's writing
- * voice bans outright. Each one is resolved into two sentences or a colon, the
- * fix that rule asks for. No sentence was added, cut or re-pitched.
+ * Source text: `docs/ki-wirkung-copy.md`, with two sets of edits on top.
+ *
+ * First, the source uses em dashes, which the site's writing voice bans
+ * outright. Each one is resolved into two sentences or a colon, the fix that
+ * rule asks for.
+ *
+ * Second, a pass for register. The source reached for clipped fragments as
+ * punchlines ("Zwei parallel, mehr nicht.", "Und was nicht.") and for swipes at
+ * unnamed competitors ("Der Punkt, an dem andere Anbieter scheitern.", "Kein
+ * Foliensatz, den nach vier Wochen niemand mehr öffnet."). Read by a VP
+ * Engineering weighing a five-figure mandate, that is swagger rather than
+ * confidence, so those lines are stated plainly instead. Every claim survives;
+ * only the delivery changed.
  */
 
 export type Lang = "de" | "en";
@@ -110,8 +119,8 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
     hero: {
       eyebrow: "Audit · 4 Wochen · Festpreis",
       heading: "Ihr Team arbeitet mit KI. Können Sie belegen, was es bringt?",
-      lede: "Lizenzen sind gekauft, die Nutzung ist unklar, und in der nächsten Budgetrunde fragt jemand nach Zahlen. Ich messe in vier Wochen, was sich tatsächlich verändert hat. Und was nicht.",
-      availability: `Nächster Audit-Slot: ${NEXT_SLOT.de}. Zwei parallel, mehr nicht.`,
+      lede: "Lizenzen sind gekauft, die Nutzung ist unklar, und in der nächsten Budgetrunde fragt jemand nach Zahlen. Ich messe in vier Wochen, was sich tatsächlich verändert hat und was nicht.",
+      availability: `Nächster Audit-Slot: ${NEXT_SLOT.de}`,
       cta: "Erstgespräch buchen (20 Min)",
       jumpLabel: "Was im Audit passiert",
     },
@@ -146,7 +155,7 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         {
           label: "Woche 2",
           title: "Ist-Aufnahme",
-          desc: "Wo Agenten heute wirklich eingesetzt werden. Sechs bis acht Gespräche à 30 Minuten, quer durch Teams und Senioritäten. Gespräche, keine anonymisierte Umfrage.",
+          desc: "Wo Agenten heute wirklich eingesetzt werden. Sechs bis acht Gespräche à 30 Minuten, quer durch Teams und Senioritäten. Das sind Gespräche und keine anonymisierte Umfrage.",
         },
         {
           label: "Woche 3",
@@ -169,10 +178,11 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         "Drei bis fünf priorisierte Maßnahmen mit Aufwandsschätzung",
         "Alle Rohdaten und Auswertungsskripte, in Ihrem Repository",
       ],
-      closing: "Kein Foliensatz, den nach vier Wochen niemand mehr öffnet.",
+      closing:
+        "Die Ergebnisse liegen als Dokument und als Skripte vor, nicht als Foliensatz.",
     },
     measurement: {
-      heading: "Der Punkt, an dem andere Anbieter scheitern",
+      heading: "Warum diese Messung trägt",
       blocks: [
         {
           title: "Messung ohne Leistungskontrolle",
@@ -207,7 +217,7 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         },
         {
           term: "Passt nicht, wenn",
-          desc: "Sie noch vor der Einführung stehen. Dann fehlt die Baseline und das Audit misst nichts. Melden Sie sich in einem Quartal.",
+          desc: "Sie noch vor der Einführung stehen. Dann fehlt die Baseline und das Audit misst nichts. Sinnvoll wird es, sobald die Werkzeuge ein Quartal im Einsatz sind.",
         },
       ],
     },
@@ -217,7 +227,7 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         {
           question: "Was, wenn das Ergebnis negativ ausfällt?",
           answer:
-            "Dann steht das im Dokument. Ein Audit, dessen Ergebnis vorher feststeht, ist keins wert. In dem Fall haben Sie eine belastbare Grundlage, Lizenzen zu reduzieren. Das rechnet sich schneller als jede Optimierung.",
+            "Dann steht das im Dokument. Ein Audit, dessen Ergebnis vorher feststeht, ist wertlos. In dem Fall haben Sie eine belastbare Grundlage, Lizenzen zu reduzieren. Das rechnet sich schneller als jede Optimierung.",
         },
         {
           question: "Bekommen Sie Zugriff auf unseren Code?",
@@ -232,12 +242,12 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         {
           question: "Warum nicht eines der fertigen Werkzeuge?",
           answer:
-            "Können Sie. Nach dem Audit wissen Sie, welche Kennzahlen bei Ihnen aussagekräftig sind. Vorher kaufen Sie ein Dashboard und lernen erst danach, was Sie eigentlich hätten messen wollen.",
+            "Das können Sie tun. Nach dem Audit wissen Sie, welche Kennzahlen bei Ihnen aussagekräftig sind. Vorher kaufen Sie ein Dashboard und stellen erst danach fest, welche Kennzahlen Sie gebraucht hätten.",
         },
       ],
     },
     close: {
-      heading: "Abschluss",
+      heading: "Nächster Schritt",
       lede: "20 Minuten. Ich stelle Fragen, Sie entscheiden danach.",
       body: "Im Gespräch klären wir, ob Ihre Datenlage ein Audit überhaupt trägt. Wenn nicht, sage ich das im Gespräch und nicht nach der Beauftragung.",
       cta: "Termin wählen",
@@ -254,13 +264,13 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
     hero: {
       eyebrow: "Audit · 4 weeks · fixed price",
       heading: "Your team works with AI. Can you show what it returns?",
-      lede: "The licences are paid for, the usage is unclear, and in the next budget round someone will ask for numbers. In four weeks I measure what actually changed. And what didn't.",
-      availability: `Next audit slot: ${NEXT_SLOT.en}. Two at a time, no more.`,
+      lede: "The licences are paid for, the usage is unclear, and in the next budget round someone will ask for numbers. In four weeks I measure what actually changed and what didn't.",
+      availability: `Next audit slot: ${NEXT_SLOT.en}`,
       cta: "Book an intro call (20 min)",
       jumpLabel: "What happens in the audit",
     },
     problem: {
-      heading: "How you know this is you",
+      heading: "How you recognise it",
       items: [
         {
           title: "The licence cost is in the budget. The return is not.",
@@ -290,7 +300,7 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         {
           label: "Week 2",
           title: "Current practice",
-          desc: "Where agents are genuinely used today. Six to eight conversations of 30 minutes, across teams and seniority levels. Conversations, not an anonymous survey.",
+          desc: "Where agents are genuinely used today. Six to eight conversations of 30 minutes, across teams and seniority levels. These are conversations and not an anonymous survey.",
         },
         {
           label: "Week 3",
@@ -305,7 +315,7 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
       ],
     },
     outcome: {
-      heading: "What you hold afterwards",
+      heading: "What you have at the end",
       items: [
         "A metric set your team can keep running without me: definitions, queries, scripts",
         "Baseline and current value, evidenced from system data rather than self-reporting",
@@ -313,10 +323,11 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         "Three to five prioritised measures with an effort estimate",
         "All raw data and analysis scripts, in your repository",
       ],
-      closing: "No slide deck that nobody opens again after four weeks.",
+      closing:
+        "The results come as a document and as scripts, not as a slide deck.",
     },
     measurement: {
-      heading: "Where other providers fail",
+      heading: "Why this measurement holds up",
       blocks: [
         {
           title: "Measurement without performance monitoring",
@@ -351,7 +362,7 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         },
         {
           term: "Does not fit if",
-          desc: "You are still before the rollout. Then the baseline is missing and the audit measures nothing. Get in touch in a quarter.",
+          desc: "You are still before the rollout. Then the baseline is missing and the audit measures nothing. It becomes worthwhile once the tools have been in use for a quarter.",
         },
       ],
     },
@@ -376,12 +387,12 @@ export const AI_IMPACT_COPY: Record<Lang, AiImpactCopy> = {
         {
           question: "Why not one of the off-the-shelf tools?",
           answer:
-            "You can. After the audit you know which metrics are meaningful in your company. Before it, you buy a dashboard and only then learn what you should have been measuring.",
+            "You can do that. After the audit you know which metrics are meaningful in your company. Before it, you buy a dashboard and only afterwards find out which metrics you needed.",
         },
       ],
     },
     close: {
-      heading: "Closing",
+      heading: "Next step",
       lede: "20 minutes. I ask the questions, you decide afterwards.",
       body: "In the call we work out whether your data even carries an audit. If it doesn't, I say so in the call and not after you have signed.",
       cta: "Pick a time",

--- a/lib/state/business-copy.ts
+++ b/lib/state/business-copy.ts
@@ -13,12 +13,18 @@
 export type Lang = "de" | "en";
 
 /**
- * Earliest quarter a new engagement can start.
+ * Earliest quarter *ongoing* work in a team can start.
  *
  * Interpolated into the hero availability line and process step 02 in both
  * languages, because four hardcoded copies drifted apart the first time the
  * date moved. Change it here and every surface follows, including the
  * `/business.md` mirrors and `/llms.txt`.
+ *
+ * It no longer gates everything on the page. Short, time-boxed mandates such
+ * as an audit or an architecture review fit alongside the day job and can
+ * start at short notice; only continuous work inside a team has to wait for
+ * this quarter. The two availabilities are stated separately because a single
+ * date turned away buyers of the short mandates, /ki-wirkung among them.
  */
 const AVAILABLE_FROM = "Q1 2027";
 
@@ -86,7 +92,20 @@ export interface BusinessCopy {
   };
   clients: { heading: string };
   pitch: { heading: string; paragraphs: string[] };
-  services: { heading: string; items: ServiceItem[] };
+  /**
+   * `note` is the one pointer from here to /ki-wirkung, rendered as a muted
+   * line under the list in the same style as `stack.note`. Deliberately not a
+   * banner or a panel: that page sells a fixed four-week mandate to whoever
+   * owns the budget, this one sells engineering capacity to the people running
+   * the teams. Giving it more weight would blur both.
+   */
+  services: {
+    heading: string;
+    items: ServiceItem[];
+    note: string;
+    noteLinkLabel: string;
+    noteHref: string;
+  };
   stack: { heading: string; note: string; groups: StackGroup[] };
   work: { heading: string };
   process: { heading: string; steps: ProcessStep[] };
@@ -144,7 +163,7 @@ export const BUSINESS_COPY: Record<Lang, BusinessCopy> = {
       eyebrow: "Freelance · Frontend & AI Engineering",
       heading: "Senior Frontend-Engineering. Und KI, die in Produktion geht.",
       lede: "Ich arbeite mit Produktteams an den schwierigen Teilen des Frontends, unabhängig vom Framework, und bringe LLM-Features über den Demo-Status hinaus.",
-      availability: `Verfügbar ab ${AVAILABLE_FROM}`,
+      availability: `Kurze Mandate sofort · Laufende Mitarbeit ab ${AVAILABLE_FROM}`,
       ctaPrimary: "Projekt anfragen",
       ctaSecondary: "Gespräch buchen",
     },
@@ -181,6 +200,9 @@ export const BUSINESS_COPY: Record<Lang, BusinessCopy> = {
           desc: "Gewachsene Frontends Stück für Stück ablösen, auch Angular nach React, ohne das Produkt anzuhalten. Abgesichert mit Tests in Jest, Vitest, Playwright und Cypress.",
         },
       ],
+      note: "Wenn die Frage lautet, was der KI-Einsatz im Team messbar gebracht hat, gibt es dafür ein eigenes vierwöchiges Audit:",
+      noteLinkLabel: "KI im Engineering messen",
+      noteHref: "/ki-wirkung",
     },
     stack: {
       heading: "Stack",
@@ -218,7 +240,7 @@ export const BUSINESS_COPY: Record<Lang, BusinessCopy> = {
         {
           num: "02",
           title: "Zuschnitt",
-          desc: `Wir klären Umfang, Auslastung und Rahmen schriftlich, bevor jemand Zeit investiert. Projektstart ab ${AVAILABLE_FROM}.`,
+          desc: `Wir klären Umfang, Auslastung und Rahmen schriftlich, bevor jemand Zeit investiert. Ein Audit oder ein Architektur-Review lässt sich kurzfristig einschieben. Für laufende Mitarbeit im Team ist ${AVAILABLE_FROM} der früheste Start.`,
         },
         {
           num: "03",
@@ -303,7 +325,7 @@ export const BUSINESS_COPY: Record<Lang, BusinessCopy> = {
       eyebrow: "Freelance · Frontend & AI Engineering",
       heading: "Senior frontend engineering. And AI that reaches production.",
       lede: "I join product teams for the hard parts of the frontend, whatever the framework, and I build LLM features that make it past the demo.",
-      availability: `Available from ${AVAILABLE_FROM}`,
+      availability: `Short mandates now · Ongoing work from ${AVAILABLE_FROM}`,
       ctaPrimary: "Start an inquiry",
       ctaSecondary: "Book a call",
     },
@@ -340,6 +362,9 @@ export const BUSINESS_COPY: Record<Lang, BusinessCopy> = {
           desc: "Replacing a legacy frontend piece by piece, Angular to React included, without pausing the product. Covered by tests in Jest, Vitest, Playwright and Cypress.",
         },
       ],
+      note: "If the question is what AI has measurably returned in your team, there is a separate four-week audit for that:",
+      noteLinkLabel: "Measuring AI in engineering",
+      noteHref: "/ai-impact",
     },
     stack: {
       heading: "Stack",
@@ -377,7 +402,7 @@ export const BUSINESS_COPY: Record<Lang, BusinessCopy> = {
         {
           num: "02",
           title: "Shape",
-          desc: `We settle scope, capacity and terms in writing, before anyone invests time. Engagements start from ${AVAILABLE_FROM}.`,
+          desc: `We settle scope, capacity and terms in writing, before anyone invests time. An audit or an architecture review can be slotted in at short notice. For ongoing work in your team, ${AVAILABLE_FROM} is the earliest start.`,
         },
         {
           num: "03",


### PR DESCRIPTION
The page copy is written outside the repo and handed over as a document.
Checking it in gives the copy in `lib/state/ai-impact-copy.ts` something to
be diffed against when either side moves.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CgmBzzapQ3h6rL7XLQecuN