### PR TITLE
Fix two Next 16 config warnings and the giscus theme race

### DIFF
--- a/components/giscus-comments-lazy.tsx
+++ b/components/giscus-comments-lazy.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { GiscusSkeleton } from "@/components/ui/skeleton";
+import { GISCUS_MIN_HEIGHT, GiscusSkeleton } from "@/components/ui/skeleton";
 
 // Lazy load Giscus comments (below the fold) in a Client Component
 const GiscusComments = dynamic(
@@ -19,4 +19,22 @@ const GiscusComments = dynamic(
   },
 );
 
-export default GiscusComments;
+/**
+ * Owns both halves of a contract the loaded component depends on: the height
+ * reservation that keeps CLS at zero, and the positioning context its loading
+ * overlay anchors to. Splitting these across files once meant a second call
+ * site — or a refactor that dropped `relative` — would send that
+ * `absolute inset-0` overlay to whatever ancestor happened to be positioned,
+ * covering unrelated article content. Keeping them here makes that undroppable.
+ *
+ * This wrapper is server-rendered even though the component inside it is not:
+ * `ssr: false` skips the dynamic import, not the client component holding it,
+ * so the reservation still reaches the prerendered HTML.
+ */
+export default function GiscusCommentsSection({ slug }: { slug: string }) {
+  return (
+    <div className="relative" style={{ minHeight: GISCUS_MIN_HEIGHT }}>
+      <GiscusComments slug={slug} />
+    </div>
+  );
+}

--- a/components/giscus-comments-lazy.tsx
+++ b/components/giscus-comments-lazy.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { GiscusSkeleton } from "@/components/ui/skeleton";
 
 // Lazy load Giscus comments (below the fold) in a Client Component
 const GiscusComments = dynamic(
@@ -9,11 +10,11 @@ const GiscusComments = dynamic(
       default: mod.GiscusComments,
     })),
   {
-    loading: () => (
-      <div className="flex items-center justify-center py-8">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
-      </div>
-    ),
+    // The same skeleton the loaded component shows while giscus boots, so the
+    // chunk arriving is invisible in layout terms. A centred spinner here used
+    // to be much shorter than the comments it stood in for, which meant the
+    // handover itself moved the page.
+    loading: () => <GiscusSkeleton />,
     ssr: false,
   },
 );

--- a/components/giscus-comments.tsx
+++ b/components/giscus-comments.tsx
@@ -2,6 +2,7 @@
 
 import { useTheme } from "next-themes";
 import { useEffect, useRef, useState } from "react";
+import { GiscusSkeleton } from "@/components/ui/skeleton";
 
 interface GiscusCommentsProps {
   slug: string;
@@ -10,7 +11,9 @@ interface GiscusCommentsProps {
 export function GiscusComments({ slug }: GiscusCommentsProps) {
   const commentsRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
+  // Readiness of the *iframe*, not of the script. See the listener below for
+  // why `script.onload` is the wrong signal to configure giscus on.
+  const [isFrameReady, setIsFrameReady] = useState(false);
   const { resolvedTheme } = useTheme();
 
   // Reset load/error state when the post changes. Done during render rather
@@ -21,8 +24,26 @@ export function GiscusComments({ slug }: GiscusCommentsProps) {
   if (prevSlug !== slug) {
     setPrevSlug(slug);
     setError(null);
-    setIsLoaded(false);
+    setIsFrameReady(false);
   }
+
+  // Giscus announces itself by posting a `{ giscus: ... }` message from inside
+  // the iframe once that iframe has actually navigated to giscus.app. That is
+  // the only safe moment to configure it: `script.onload` fires when client.js
+  // finishes downloading, before the iframe it injects has left about:blank,
+  // so a `postMessage(..., "https://giscus.app")` at that point is rejected
+  // with a target-origin mismatch and the config is silently dropped.
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== "https://giscus.app") return;
+      if (typeof event.data !== "object" || event.data === null) return;
+      if (!("giscus" in event.data)) return;
+      setIsFrameReady(true);
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
 
   // Initialize Giscus (only once per slug)
   useEffect(() => {
@@ -59,18 +80,13 @@ export function GiscusComments({ slug }: GiscusCommentsProps) {
       console.error("Failed to load Giscus script");
     };
 
-    // Mark as loaded when script loads
-    script.onload = () => {
-      setIsLoaded(true);
-    };
-
     currentRef.appendChild(script);
 
     // Cleanup function
     return () => {
       if (currentRef) {
         currentRef.innerHTML = "";
-        setIsLoaded(false);
+        setIsFrameReady(false);
       }
     };
   }, [slug]);
@@ -79,7 +95,7 @@ export function GiscusComments({ slug }: GiscusCommentsProps) {
   // This approach uses giscus's native themes which work reliably
   // while still loading our custom CSS initially
   useEffect(() => {
-    if (!isLoaded) return;
+    if (!isFrameReady) return;
 
     const iframe = document.querySelector<HTMLIFrameElement>(
       "iframe.giscus-frame",
@@ -100,21 +116,34 @@ export function GiscusComments({ slug }: GiscusCommentsProps) {
       },
       "https://giscus.app",
     );
-  }, [resolvedTheme, isLoaded]);
+  }, [resolvedTheme, isFrameReady]);
+
+  // The heading and the height reservation are owned by the server-rendered
+  // caller (components/mdx-layout.tsx); this component renders only what has
+  // to be client-side.
+  if (error) {
+    return (
+      // red-700 on the tinted panel, not red-500: over the light theme's
+      // cream the 500 measured 3.01:1 against the panel tint, short of the
+      // 4.5:1 WCAG AA wants for body text. Dark mode keeps a lighter red.
+      <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-red-700 dark:text-red-400">
+        <p>{error}</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="mt-16">
-      <h2 className="mb-6 font-bold text-2xl">Comments</h2>
-      {/* red-700 on the tinted panel, not red-500: over the light theme's
-          cream the 500 measured 3.01:1 against the panel tint, short of the
-          4.5:1 WCAG AA wants for body text. Dark mode keeps a lighter red. */}
-      {error ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-red-700 dark:text-red-400">
-          <p>{error}</p>
+    <>
+      <div ref={commentsRef} className="giscus" />
+      {/* Overlaid rather than swapped: the giscus container above stays
+          mounted underneath while the skeleton covers it, so the script always
+          has its mount point and the iframe can size itself from a rendered
+          frame. Rendering one *or* the other would tear down the iframe. */}
+      {!isFrameReady && (
+        <div className="absolute inset-0">
+          <GiscusSkeleton />
         </div>
-      ) : (
-        <div ref={commentsRef} className="giscus" />
       )}
-    </div>
+    </>
   );
 }

--- a/components/giscus-comments.tsx
+++ b/components/giscus-comments.tsx
@@ -1,20 +1,42 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { GiscusSkeleton } from "@/components/ui/skeleton";
 
 interface GiscusCommentsProps {
   slug: string;
 }
 
+/**
+ * How long to wait for the iframe to announce itself before telling the reader
+ * something went wrong. `script.onerror` only covers client.js failing to
+ * download; everything after that — a content blocker that lets the script
+ * through but blocks the giscus.app frame, a connection dropped mid-navigation,
+ * a frame that errors on entry — produces no event at all. Without a deadline
+ * those cases leave a skeleton pulsing forever.
+ *
+ * Generous on purpose: the giscus container is never torn down when this fires,
+ * so a frame that is merely slow still arrives, flips the state back to ready
+ * and removes the notice on its own.
+ */
+const GISCUS_LOAD_TIMEOUT_MS = 15_000;
+
+const GISCUS_ORIGIN = "https://giscus.app";
+
+type Status = "loading" | "ready" | "error";
+
 export function GiscusComments({ slug }: GiscusCommentsProps) {
   const commentsRef = useRef<HTMLDivElement>(null);
-  const [error, setError] = useState<string | null>(null);
-  // Readiness of the *iframe*, not of the script. See the listener below for
-  // why `script.onload` is the wrong signal to configure giscus on.
-  const [isFrameReady, setIsFrameReady] = useState(false);
+  const [status, setStatus] = useState<Status>("loading");
   const { resolvedTheme } = useTheme();
+
+  const giscusTheme = resolvedTheme === "light" ? "light" : "dark";
+  // The message listener has to post the *current* theme, but re-subscribing on
+  // every theme change would drop messages during the swap. A ref keeps the
+  // listener stable and still current.
+  const themeRef = useRef(giscusTheme);
+  themeRef.current = giscusTheme;
 
   // Reset load/error state when the post changes. Done during render rather
   // than inside the effect below — React's documented pattern for deriving
@@ -23,27 +45,61 @@ export function GiscusComments({ slug }: GiscusCommentsProps) {
   const [prevSlug, setPrevSlug] = useState(slug);
   if (prevSlug !== slug) {
     setPrevSlug(slug);
-    setError(null);
-    setIsFrameReady(false);
+    setStatus("loading");
   }
+
+  // Scoped to our own container rather than the document: on a slug change the
+  // old frame can still be in the tree for a tick, and a page with two comment
+  // sections would otherwise configure whichever frame happened to be first.
+  const currentFrame = useCallback(
+    () =>
+      commentsRef.current?.querySelector<HTMLIFrameElement>(
+        "iframe.giscus-frame",
+      ) ?? null,
+    [],
+  );
+
+  const postTheme = useCallback(
+    (theme: string) => {
+      currentFrame()?.contentWindow?.postMessage(
+        { giscus: { setConfig: { theme } } },
+        GISCUS_ORIGIN,
+      );
+    },
+    [currentFrame],
+  );
 
   // Giscus announces itself by posting a `{ giscus: ... }` message from inside
   // the iframe once that iframe has actually navigated to giscus.app. That is
   // the only safe moment to configure it: `script.onload` fires when client.js
   // finishes downloading, before the iframe it injects has left about:blank,
-  // so a `postMessage(..., "https://giscus.app")` at that point is rejected
-  // with a target-origin mismatch and the config is silently dropped.
+  // so a `postMessage(..., GISCUS_ORIGIN)` at that point is rejected with a
+  // target-origin mismatch and the config is silently dropped.
+  //
+  // The theme is re-posted on *every* message rather than once on a latched
+  // "ready" flag. Giscus re-navigates its own frame when a reader signs in, and
+  // the reloaded document falls back to the `data-theme` stylesheet — a config
+  // sent only on the first message never reaches it, and the frame reverts to
+  // whichever theme that stylesheet describes.
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      if (event.origin !== "https://giscus.app") return;
+      if (event.origin !== GISCUS_ORIGIN) return;
       if (typeof event.data !== "object" || event.data === null) return;
       if (!("giscus" in event.data)) return;
-      setIsFrameReady(true);
+      // Ignore anything from a frame we no longer own. A resize message queued
+      // by the previous slug's iframe can land after the reset above, and
+      // treating it as readiness would hide the skeleton over a frame that does
+      // not exist yet.
+      const frame = currentFrame();
+      if (!frame || event.source !== frame.contentWindow) return;
+
+      setStatus("ready");
+      postTheme(themeRef.current);
     };
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, []);
+  }, [currentFrame, postTheme]);
 
   // Initialize Giscus (only once per slug)
   useEffect(() => {
@@ -57,7 +113,7 @@ export function GiscusComments({ slug }: GiscusCommentsProps) {
     currentRef.innerHTML = "";
 
     const script = document.createElement("script");
-    script.src = "https://giscus.app/client.js";
+    script.src = `${GISCUS_ORIGIN}/client.js`;
     script.setAttribute("data-repo", "jomaendle/personal-website-2025");
     script.setAttribute("data-repo-id", "R_kgDONtoXmg");
     script.setAttribute("data-category", "Blog Comments");
@@ -74,73 +130,74 @@ export function GiscusComments({ slug }: GiscusCommentsProps) {
     script.crossOrigin = "anonymous";
     script.async = true;
 
-    // Add error handling
+    // Covers the script itself failing to download. Everything past that point
+    // is covered by the deadline below.
     script.onerror = () => {
-      setError("Failed to load comments. Please try refreshing the page.");
+      setStatus("error");
       console.error("Failed to load Giscus script");
     };
 
     currentRef.appendChild(script);
 
-    // Cleanup function
+    const timeoutId = window.setTimeout(() => {
+      setStatus((current) => (current === "loading" ? "error" : current));
+    }, GISCUS_LOAD_TIMEOUT_MS);
+
     return () => {
-      if (currentRef) {
-        currentRef.innerHTML = "";
-        setIsFrameReady(false);
-      }
+      window.clearTimeout(timeoutId);
+      currentRef.innerHTML = "";
     };
   }, [slug]);
 
-  // Handle theme changes by switching to built-in giscus themes
+  // Handle theme changes by switching to built-in giscus themes.
   // This approach uses giscus's native themes which work reliably
-  // while still loading our custom CSS initially
+  // while still loading our custom CSS initially.
   useEffect(() => {
-    if (!isFrameReady) return;
+    if (status !== "ready") return;
+    postTheme(giscusTheme);
+  }, [giscusTheme, status, postTheme]);
 
-    const iframe = document.querySelector<HTMLIFrameElement>(
-      "iframe.giscus-frame",
-    );
-    if (!iframe) return;
-
-    // Use giscus built-in themes for reliable theme switching
-    // The custom CSS provides the base styling, built-in themes handle colors
-    const giscusTheme = resolvedTheme === "light" ? "light" : "dark";
-
-    iframe.contentWindow?.postMessage(
-      {
-        giscus: {
-          setConfig: {
-            theme: giscusTheme,
-          },
-        },
-      },
-      "https://giscus.app",
-    );
-  }, [resolvedTheme, isFrameReady]);
-
-  // The heading and the height reservation are owned by the server-rendered
-  // caller (components/mdx-layout.tsx); this component renders only what has
-  // to be client-side.
-  if (error) {
-    return (
-      // red-700 on the tinted panel, not red-500: over the light theme's
-      // cream the 500 measured 3.01:1 against the panel tint, short of the
-      // 4.5:1 WCAG AA wants for body text. Dark mode keeps a lighter red.
-      <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-red-700 dark:text-red-400">
-        <p>{error}</p>
-      </div>
-    );
-  }
-
+  // The heading and the height reservation are owned by the caller
+  // (components/giscus-comments-lazy.tsx and components/mdx-layout.tsx); this
+  // component renders only what has to be client-side.
   return (
     <>
-      <div ref={commentsRef} className="giscus" />
+      <div
+        ref={commentsRef}
+        className="giscus"
+        aria-busy={status === "loading"}
+      />
+
+      {/* The skeleton is decorative and hidden from assistive tech, so without
+          this the reader hears "Comments" followed by silence and never learns
+          whether the widget is loading, arrived, or failed. */}
+      <p className="sr-only" role="status">
+        {status === "loading" ? "Loading comments…" : ""}
+        {status === "ready" ? "Comments loaded." : ""}
+      </p>
+
+      {status === "error" && (
+        // red-700 on the tinted panel, not red-500: over the light theme's
+        // cream the 500 measured 3.01:1 against the panel tint, short of the
+        // 4.5:1 WCAG AA wants for body text. Dark mode keeps a lighter red.
+        <div
+          role="alert"
+          className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-red-700 dark:text-red-400"
+        >
+          <p>Failed to load comments. Please try refreshing the page.</p>
+        </div>
+      )}
+
       {/* Overlaid rather than swapped: the giscus container above stays
           mounted underneath while the skeleton covers it, so the script always
           has its mount point and the iframe can size itself from a rendered
-          frame. Rendering one *or* the other would tear down the iframe. */}
-      {!isFrameReady && (
-        <div className="absolute inset-0">
+          frame. Rendering one *or* the other would tear down the iframe.
+          Opaque and click-through: the frame paints its own placeholder as soon
+          as it navigates, which would otherwise show through the gaps between
+          the shimmer blocks, and a transparent overlay would still swallow
+          clicks aimed at the frame underneath it. */}
+      {status === "loading" && (
+        <div className="pointer-events-none absolute inset-0 bg-background">
           <GiscusSkeleton />
         </div>
       )}

--- a/components/mdx-layout.tsx
+++ b/components/mdx-layout.tsx
@@ -11,6 +11,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { Footer } from "@/components/ui/footer";
 import { ScrollProgress } from "@/components/ui/scroll-progress";
+import { GISCUS_MIN_HEIGHT } from "@/components/ui/skeleton";
 import { ViewCounter } from "@/components/view-counter";
 import { SITE } from "@/lib/config/site";
 import { BLOG_POSTS } from "@/lib/state/blog";
@@ -164,7 +165,21 @@ export default function MdxLayout({
                 <div className="prose">{children}</div>
 
                 <hr className="my-12" />
-                <GiscusComments slug={slug} />
+                {/* Heading and the reserved box live here, in server-rendered
+                    markup, rather than inside <GiscusComments>. That component
+                    is loaded with `ssr: false`, so anything it owns is absent
+                    from the prerendered HTML and would grow the page when it
+                    mounts — pushing everything below it down. Reserving the
+                    space up here is what keeps that shift at zero. */}
+                <section className="mt-16">
+                  <h2 className="mb-6 font-bold text-2xl">Comments</h2>
+                  <div
+                    className="relative"
+                    style={{ minHeight: GISCUS_MIN_HEIGHT }}
+                  >
+                    <GiscusComments slug={slug} />
+                  </div>
+                </section>
                 <hr className="my-12" />
                 <ReadMoreArticles currentSlug={slug} />
                 <NewsletterForm />

--- a/components/mdx-layout.tsx
+++ b/components/mdx-layout.tsx
@@ -11,7 +11,6 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { Footer } from "@/components/ui/footer";
 import { ScrollProgress } from "@/components/ui/scroll-progress";
-import { GISCUS_MIN_HEIGHT } from "@/components/ui/skeleton";
 import { ViewCounter } from "@/components/view-counter";
 import { SITE } from "@/lib/config/site";
 import { BLOG_POSTS } from "@/lib/state/blog";
@@ -165,20 +164,15 @@ export default function MdxLayout({
                 <div className="prose">{children}</div>
 
                 <hr className="my-12" />
-                {/* Heading and the reserved box live here, in server-rendered
-                    markup, rather than inside <GiscusComments>. That component
-                    is loaded with `ssr: false`, so anything it owns is absent
-                    from the prerendered HTML and would grow the page when it
-                    mounts — pushing everything below it down. Reserving the
-                    space up here is what keeps that shift at zero. */}
+                {/* The heading lives here, in server-rendered markup, rather
+                    than inside the comments component: that one is loaded with
+                    `ssr: false`, so anything it owns is absent from the
+                    prerendered HTML and would grow the page when it mounts.
+                    <GiscusComments> carries its own height reservation for the
+                    same reason — see components/giscus-comments-lazy.tsx. */}
                 <section className="mt-16">
                   <h2 className="mb-6 font-bold text-2xl">Comments</h2>
-                  <div
-                    className="relative"
-                    style={{ minHeight: GISCUS_MIN_HEIGHT }}
-                  >
-                    <GiscusComments slug={slug} />
-                  </div>
+                  <GiscusComments slug={slug} />
                 </section>
                 <hr className="my-12" />
                 <ReadMoreArticles currentSlug={slug} />

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -79,6 +79,62 @@ function BaselineStatusSkeleton({ className }: { className?: string }) {
   );
 }
 
-// `Skeleton` stays module-local: it is the shared shimmer block the two
-// exported skeletons are built from, and has no consumers of its own.
-export { BaselineStatusSkeleton, SandpackSkeleton };
+/**
+ * Height the giscus iframe settles at once loaded, in px.
+ *
+ * Measured against production at both 500px and 1280px viewport widths — the
+ * empty state is width-independent (a reaction bar, a comment-count row and
+ * the comment box all stack at fixed heights), so one number covers every
+ * breakpoint. Reserving it in the *server-rendered* parent is what buys the
+ * zero CLS: the lazy comment component is `ssr: false`, so nothing about it
+ * reaches the prerendered HTML and a reservation made inside it would arrive
+ * too late to stop the page from growing.
+ *
+ * Posts that already have comments still exceed this and shift by the
+ * difference. That is unavoidable client-side — the count isn't known until
+ * giscus answers — and it is still far better than growing from zero.
+ */
+const GISCUS_MIN_HEIGHT = 372;
+
+function GiscusSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("w-full", className)}
+      style={{ contain: "layout style paint" }}
+    >
+      {/* Reaction pills */}
+      <div className="mb-4 flex gap-2">
+        <Skeleton className="size-9 rounded-full" />
+        <Skeleton className="size-9 rounded-full" />
+        <Skeleton className="size-9 rounded-full" />
+      </div>
+
+      {/* "N Comments" heading */}
+      <Skeleton className="mb-4 h-5 w-28" />
+
+      {/* Comment box, with its Write/Preview tab row */}
+      <div className="rounded-md border border-border">
+        <div className="flex gap-3 border-border border-b px-3 py-2">
+          <Skeleton className="h-5 w-14" />
+          <Skeleton className="h-5 w-16" />
+        </div>
+        <div className="space-y-3 p-3">
+          <Skeleton className="h-20 w-full rounded" />
+          <div className="flex justify-end">
+            <Skeleton className="h-8 w-28 rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// `Skeleton` stays module-local: it is the shared shimmer block the exported
+// skeletons are built from, and has no consumers of its own.
+export {
+  BaselineStatusSkeleton,
+  GISCUS_MIN_HEIGHT,
+  GiscusSkeleton,
+  SandpackSkeleton,
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,10 @@ import createMDX from "@next/mdx";
 const nextConfig = {
   pageExtensions: ["mdx", "jsx", "js", "ts", "tsx"],
   experimental: {
-    viewTransition: true,
+    // No `viewTransition` flag: Next 16 removed it, and this site never needed
+    // it anyway — navigation transitions come from `next-view-transitions`
+    // (which drives `document.startViewTransition` itself), not from React's
+    // `<ViewTransition>`.
     optimizePackageImports: [
       "framer-motion",
       "lucide-react",
@@ -58,16 +61,11 @@ const nextConfig = {
     ].join("; ");
 
     return [
-      // Immutable Next.js static chunks (hashed JS/CSS)
-      {
-        source: "/_next/static/:path*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
-          },
-        ],
-      },
+      // No rule for `/_next/static/:path*`. Next serves its own hashed chunks
+      // as `public,max-age=31536000,immutable` already, so the rule only
+      // duplicated the framework's own header — and Next 16 warns about custom
+      // Cache-Control under `/_next/` because it can break dev behaviour.
+      // Everything below is in `public/`, which gets no automatic caching.
       // Self-hosted fonts
       {
         source: "/fonts/:path*",


### PR DESCRIPTION
Cleans up the warnings left over from the Next.js 16.3 upgrade, fixes a giscus bug they surfaced along the way, and stops the comments section from shifting the page.

## 1. `experimental.viewTransition` — removed

Next 16 dropped the flag; React's `<ViewTransition>` needs no config in the App Router. It was inert here regardless — navigation transitions come from `next-view-transitions`, which drives `document.startViewTransition` itself and never read it.

## 2. `/_next/static` Cache-Control rule — removed

The rule only restated the header Next already sets. Verified against production, where the two differ in whitespace and are therefore visibly from different sources:

```
/_next/static/…/chunk.css   public,max-age=31536000,immutable     ← Next
/fonts/GeistVF.woff2        public, max-age=31536000, immutable   ← ours
```

The `public/` rules below it are kept — those assets get no automatic caching.

Both warnings are gone; `next dev` and `next start` now print only `✓ Running next.config.mjs`.

## 3. Giscus target-origin mismatch

Every article load logged:

```
Failed to execute 'postMessage' on 'DOMWindow': the target origin provided
('https://giscus.app') does not match the recipient window's origin
```

The theme was posted on `script.onload`, which only means `client.js` finished downloading — the iframe it injects hasn't left `about:blank` yet, so the message was rejected and the config silently dropped. It now waits for giscus's own `{ giscus: … }` message, posted once the frame is genuinely on `giscus.app`.

The accompanying `404`s from `/api/discussions` are **not** a bug and are untouched here: that's what giscus returns for a post with no discussion yet. Repo, `repo-id` and `category-id` were all verified correct (public repo, Discussions enabled, API returns a valid empty discussion).

## 4. Comments no longer shift the page

The lazy wrapper is `ssr: false`, so nothing about comments reached the prerendered HTML — the client mounting it grew the page and pushed the read-more and newsletter sections down. A reservation *inside* that component can't help, since mounting it is itself the shift.

The heading and a `372px` box now live in `mdx-layout.tsx` (server-rendered), with `GiscusSkeleton` overlaid until the frame is ready. `372px` is where giscus settles, measured at both 500px and 1280px widths — the empty state is width-independent.

Posts that already have comments still exceed the reservation and shift by the difference; that's not knowable client-side before giscus answers, and it beats growing from zero.

## Verification

Against a local production build (`next build && next start`):

```
                 box     iframe
initial          372px   372px
after-scroll-2s  372px   372px
after-10s        372px   372px

shifts after 1s: []
```

The reservation now appears in the prerendered HTML (`min-height:372px` and `>Comments<`, each 1 occurrence — both were 0 before). Residual page CLS is `0.0079`, all in the first 550ms and all from `whileInView` motion reveals elsewhere on the page, not from comments.

## 5. Review follow-ups — the widget gets a failure path and a voice

A `high` code review of this branch cleared items 1–4 (the `viewTransition` flag is gone from Next 16.3's server code entirely; the `/_next/static` headers are Next's own; the new `<h2>Comments</h2>` stays out of the TOC because `sidebar-navigation.tsx` scopes its scan to `.prose`) and raised five findings against the readiness handling, all now fixed.

The root cause was shared: `isFrameReady` was a **latched boolean standing in for a stream of events**. Giscus posts many `{ giscus: … }` messages over a frame's life, and the frame can be recreated more than once per mount — so the latch lost information in both directions.

**Nothing covered a frame that never arrives.** `script.onerror` only fires if `client.js` fails to download. A content blocker that permits the script but blocks the `giscus.app` frame, a connection dropped mid-navigation, a lazy frame that errors on entry — none produce an event, so `error` stayed `null` and an `aria-hidden` skeleton pulsed forever. A 15s deadline now shows a notice, *without* tearing down the container: a merely-slow frame still arrives, flips the state back to ready and clears the notice itself.

**Nothing covered a frame that arrives twice.** Giscus re-navigates its own iframe when a reader signs in, and the reloaded document falls back to the `data-theme` stylesheet — a `setConfig` sent once on the first message never reaches it, so the theme reverted. The theme is now posted on every message, read through a ref so the listener stays subscribed across theme changes.

**Messages are now bound to the frame we own,** via `event.source !== frame.contentWindow`. A `resizeHeight` queued by the previous slug's iframe could land after the render-phase reset and flip readiness back to `true` before the new script had built its frame — the lookup then returned `null`, the effect bailed, and the latch prevented it from ever re-running. The frame lookup is also scoped to the container now rather than `document`.

**Accessibility.** The skeleton is decorative and `aria-hidden`, so a screen reader heard "Comments" followed by silence for the entire load — and, combined with the above, was never told whether it was loading or broken. Adds `aria-busy` on the container plus a persistent `sr-only` live region ("Loading comments…" → "Comments loaded.") and `role="alert"` on the error panel.

**Overlay.** Now `pointer-events-none bg-background`. It was fully transparent, so the frame's own placeholder showed through the gaps between shimmer blocks once it navigated, and it swallowed clicks aimed at the frame underneath.

**The reservation moved into the lazy wrapper.** The `absolute inset-0` overlay only positioned correctly because the single call site happened to wrap it in `relative` + `minHeight`. A second call site — or a refactor dropping `relative` — would have sent the overlay to the nearest positioned ancestor, plausibly the editorial shell's `relative z-20`, covering article content. `giscus-comments-lazy.tsx` now owns both halves. `ssr: false` skips the dynamic import, not the client component holding it, so the reservation still reaches the prerendered HTML.

### Verification

`tsc --noEmit`, `biome check` and `next build` pass. `min-height:372px` still present in the prerendered HTML, so the zero-CLS result above is unchanged. Live in a browser: frame ready at ~2s, `aria-busy` → `false`, status reads "Comments loaded.", overlay removed, box holding 372px; toggling the theme repainted the frame light→dark, confirming `setConfig` lands.

Two paths are reasoned from the message flow rather than observed: the 15s timeout branch, and the sign-in re-navigation that motivated the re-post (it needs a real GitHub OAuth round trip).

## Note — the custom stylesheet is a fallback, not dead code

Fixing the postMessage race means the built-in `light`/`dark` themes now actually apply, where before the failing message left `public/giscus-custom-theme.css` in place. That matches the stated intent in the code, and the custom CSS is keyed to `prefers-color-scheme` (`:root` dark, `@media (prefers-color-scheme: light)` at line 96) — i.e. the OS setting, not the site's theme toggle — so it was wrong for anyone toggling against their system.

An earlier draft of this description concluded that `public/giscus-custom-theme.css`, `app/api/giscus-theme/route.ts` and its CORS header block were therefore unreachable, and slated them for a follow-up cleanup. **That was wrong** — they still have a job. `data-theme` points the frame at that URL, so it styles the frame during every window in which `setConfig` has not yet landed:

- **First load** — between the frame navigating and its first `{ giscus: … }` message. Invisible in practice, since the skeleton covers the frame for exactly that interval.
- **Sign-in return** — giscus re-navigates its own frame, and the reloaded document goes back to the stylesheet. Nothing covers this one: the component is already `ready`, so the reader sees the frame repaint. The re-post added in commit 2 is what pulls it back to the right theme, but the stylesheet is what it looks like in the meantime.

Deleting these would replace that fallback with giscus's unstyled default — a light-themed flash on a dark page for anyone signing in. They stay, and there is no follow-up cleanup to schedule.

Worth doing separately, though: the stylesheet's `prefers-color-scheme` split should be a `.dark`/`:root` split driven by the same class the site toggle sets, so the fallback agrees with the page instead of with the OS. That is a real fix rather than a removal, and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
